### PR TITLE
docker: Install missing dependency

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -3,8 +3,11 @@
   apt_key: keyserver=hkp://p80.pool.sks-keyservers.net:80
     id=58118E89F3A912897C070ADBF76221572C52609D
 
-- name: Install apt HTTPS transport
-  apt: pkg=apt-transport-https update-cache=yes cache_valid_time=3600
+- name: Install apt HTTPS transport and python-pip
+  apt: pkg={{ item }} update-cache=yes cache_valid_time=3600
+  with_items:
+    - apt-transport-https
+    - python-pip
 
 - name: Add Docker repository.
   apt_repository: repo='deb https://apt.dockerproject.org/repo debian-{{ ansible_distribution_release }} main'


### PR DESCRIPTION
python-pip was missing:
```
failed: [katharina.chaospott.de] (item=docker-py) => {"changed": false, "failed": true, "item": "docker-py", "msg": "Unable to find any of pip2, pip to use.  pip needs to be installed."}
failed: [katharina.chaospott.de] (item=docker-compose) => {"changed": false, "failed": true, "item": "docker-compose", "msg": "Unable to find any of pip2, pip to use.  pip needs to be installed."}
```