### PR TITLE
mattermost: Update matterbridge nick format

### DIFF
--- a/roles/mattermost/templates/matterbridge.j2
+++ b/roles/mattermost/templates/matterbridge.j2
@@ -23,7 +23,7 @@ Team="spaceapi"
 Login="bridge_bot"
 Password="{{ mattermost_bridge_bot_password }}"
 
-RemoteNickFormat="<{NICK}> "
+RemoteNickFormat="[{PROTOCOL}/{NICK}] "
 PrefixMessagesWithNick=true
 EditDisable=false
 EditSuffix=" (edited)"
@@ -31,5 +31,5 @@ EditSuffix=" (edited)"
 [irc.spaceapi]
 Server="chat.freenode.net:6667"
 Nick="bridge_bot"
-RemoteNickFormat="<{NICK}> "
+RemoteNickFormat="[{PROTOCOL}/{NICK}] "
 


### PR DESCRIPTION
I like having the protocol in the nick. It makes it a bit more obvious that the nick tag is not a mention.