### PR TITLE
adds allow access origin header

### DIFF
--- a/roles/directory/files/directory.spaceapi.net
+++ b/roles/directory/files/directory.spaceapi.net
@@ -1,4 +1,5 @@
 directory.spaceapi.net {
+  header / Access-Control-Allow-Origin "*"
   redir / https://spaceapi.fixme.ch/directory.json 307
 }
 


### PR DESCRIPTION
caddy somehow set the header to all lowercase, i'm not a 100% sure about the standard but i think its not allowed... but better than nothing.