### PR TITLE
Use handler to restart caddy if needed

### DIFF
--- a/roles/directory/tasks/main.yml
+++ b/roles/directory/tasks/main.yml
@@ -1,13 +1,9 @@
 - name: Configure reverseproxy
-  block:
-    - copy:
-        src: directory.spaceapi.net
-        dest: /etc/caddy/sites
-        owner: 'www-data'
-        group: 'www-data'
-        mode: 0755
-
-    - systemd:
-        name: caddy
-        state: restarted
-
+  copy:
+    src: directory.spaceapi.net
+    dest: /etc/caddy/sites
+    owner: 'www-data'
+    group: 'www-data'
+    mode: 0755
+  notify:
+    - restart caddy

--- a/roles/mattermost/tasks/main.yml
+++ b/roles/mattermost/tasks/main.yml
@@ -72,14 +72,11 @@
     state: present
 
 - name: Configure reverseproxy
-  block:
-    - copy:
-        src: chat.spaceapi.net
-        dest: /etc/caddy/sites
-        owner: 'www-data'
-        group: 'www-data'
-        mode: 0755
-
-    - systemd:
-        name: caddy
-        state: restarted
+  copy:
+    src: chat.spaceapi.net
+    dest: /etc/caddy/sites
+    owner: 'www-data'
+    group: 'www-data'
+    mode: 0755
+  notify:
+    - restart caddy

--- a/roles/reverseproxy/handlers/main.yml
+++ b/roles/reverseproxy/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: restart caddy
   systemd: name=caddy state=restarted
+
+- name: reload systemd
+  systemd: daemon_reload=yes

--- a/roles/reverseproxy/handlers/main.yml
+++ b/roles/reverseproxy/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart caddy
+  systemd: name=caddy state=restarted

--- a/roles/reverseproxy/tasks/main.yaml
+++ b/roles/reverseproxy/tasks/main.yaml
@@ -15,6 +15,9 @@
           owner: root
           group: root
           mode: 0644
+        notify:
+          - reload systemd
+          - restart caddy
 
       - file:
           path: /etc/caddy
@@ -22,6 +25,7 @@
           owner: 'www-data'
           group: 'www-data'
           mode: 0755
+        notify: restart caddy
 
       - file:
           path: /etc/caddy/sites
@@ -29,6 +33,7 @@
           owner: 'www-data'
           group: 'www-data'
           mode: 0755
+        notify: restart caddy
 
       - copy:
           src: Caddyfile
@@ -36,8 +41,4 @@
           owner: 'www-data'
           group: 'www-data'
           mode: 0644
-
-      - systemd:
-          daemon_reload: yes
-          name: caddy
-          state: restarted
+        notify: restart caddy


### PR DESCRIPTION
This cleans up the script and makes the Ansible script more idempotent (i.e. caddy gets only restarted if actually needed)