### PR TITLE
Add https forwarding to http entry point

### DIFF
--- a/roles/reverseproxy/files/traefik.toml
+++ b/roles/reverseproxy/files/traefik.toml
@@ -6,6 +6,8 @@ defaultEntryPoints = ["https","http"]
 [entryPoints]
   [entryPoints.http]
   address = ":80"
+    [entryPoints.http.redirect]
+    entryPoint = "https"
   [entryPoints.https]
   address = ":443"
     [entryPoints.https.tls]


### PR DESCRIPTION
Fixes the missing https redirect for traefik.