### PR TITLE
Use a fixed version of the docker and docker-compose pip package

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -24,9 +24,8 @@
 - name: Install docker-compose.
   pip:
     name:
-      - docker
-      - docker-compose
-    state: latest
+      - docker~=3.7.0
+      - docker-compose~=1.23.2
 
 - name: Enable Docker.
   service: name=docker state=started enabled=yes


### PR DESCRIPTION
This avoids unintended upgrade of these packages which may contain
breaking changes.