### PR TITLE
Victoriametrics

### DIFF
--- a/deployment/roles/docker/tasks/main.yml
+++ b/deployment/roles/docker/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Docker repository key.
   apt_key:
-    keyserver: hkp://p80.pool.sks-keyservers.net:80
+    url: https://download.docker.com/linux/debian/gpg
     id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 
 - name: Install apt HTTPS transport and python-pip

--- a/deployment/roles/metrics/files/docker-compose.yml
+++ b/deployment/roles/metrics/files/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   prometheus:
     image: "prom/prometheus:v2.10.0"
     depends_on:
-      - influx
+      - victoriametrics
     networks:
       - default
       - traefik-web
@@ -41,6 +41,7 @@ services:
     restart: always
     environment:
       GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD}"
+      GF_INSTALL_PLUGINS: "grafana-piechart-panel,raintank-worldping-app"
     volumes:
     - "${DATA_FOLDER}/grafana:/var/lib/grafana"
     labels:

--- a/deployment/roles/metrics/files/docker-compose.yml
+++ b/deployment/roles/metrics/files/docker-compose.yml
@@ -1,22 +1,18 @@
 version: "3.0"
 
 services:
-  influx:
-    image: "influxdb:1.7.6-alpine"
+  victoriametrics:
+    image: victoriametrics/victoria-metrics
+    volumes:
+      - "${DATA_FOLDER}/victoriametrics:/storage:rw"
+    command:
+      - '--storageDataPath=/storage'
+      - '--graphiteListenAddr=:2003'
+      - '--opentsdbListenAddr=:4242'
+      - '--httpListenAddr=:8428'
     networks:
       - default
     restart: always
-    volumes:
-    - "${DATA_FOLDER}/influxdb:/var/lib/influxdb:rw"
-    labels:
-    - "traefik.enable=false"
-    environment:
-      INFLUXDB_ADMIN_ENABLED: "true"
-      INFLUXDB_DB: "spaceapi"
-      INFLUXDB_ADMIN_USER: "${INFLUXDB_ADMIN_USER}"
-      INFLUXDB_ADMIN_PASSWORD: "${INFLUXDB_ADMIN_PASSWORD}"
-      INFLUXDB_USER: "${INFLUXDB_USER}"
-      INFLUXDB_USER_PASSWORD: "${INFLUXDB_USER_PASSWORD}"
 
   prometheus:
     image: "prom/prometheus:v2.10.0"

--- a/deployment/roles/metrics/templates/env.j2
+++ b/deployment/roles/metrics/templates/env.j2
@@ -1,8 +1,4 @@
 DATA_FOLDER={{ docker_data_folder }}/metrics
-INFLUXDB_ADMIN_USER={{ influxdb_admin_user }}
-INFLUXDB_ADMIN_PASSWORD={{ influxdb_admin_password }}
-INFLUXDB_USER={{ influxdb_user }}
-INFLUXDB_USER_PASSWORD={{ influxdb_user_password }}
 
 GRAFANA_ADMIN_PASSWORD={{ grafana_admin_password }}
 

--- a/deployment/roles/metrics/templates/prometheus.yml.j2
+++ b/deployment/roles/metrics/templates/prometheus.yml.j2
@@ -2,11 +2,12 @@ global:
   scrape_interval: 1m
   evaluation_interval: 1m
 
-remote_write:
-  - url: "http://influx:8086/api/v1/prom/write?db=spaceapi&u={{ influxdb_user }}&p={{ influxdb_user_password }}"
-remote_read:
-  - url: "http://influx:8086/api/v1/prom/read?db=spaceapi&u={{ influxdb_user }}&p={{ influxdb_user_password }}"
 
+remote_write:
+  - url: http://victoriametrics-addr:8428/api/v1/write
+    queue_config:
+      max_samples_per_send: 10000
+      max_shards: 30
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/deployment/roles/metrics/templates/prometheus.yml.j2
+++ b/deployment/roles/metrics/templates/prometheus.yml.j2
@@ -4,7 +4,7 @@ global:
 
 
 remote_write:
-  - url: http://victoriametrics-addr:8428/api/v1/write
+  - url: http://victoriametrics:8428/api/v1/write
     queue_config:
       max_samples_per_send: 10000
       max_shards: 30
@@ -36,3 +36,6 @@ scrape_configs:
   - job_name: 'server'
     static_configs:
     - targets: ['{{ domain }}:9100']
+  - job_name: 'victoriametrics'
+    static_configs:
+    - targets: ['victoriametrics:8428']

--- a/nodes/terraform.tfstate.d/dev/terraform.tfstate
+++ b/nodes/terraform.tfstate.d/dev/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
-  "terraform_version": "0.12.1",
-  "serial": 101,
+  "terraform_version": "0.12.6",
+  "serial": 112,
   "lineage": "8ee0545c-ae97-4b13-5819-5ffd9854b205",
   "outputs": {},
   "resources": []

--- a/persistent/terraform.tfstate
+++ b/persistent/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
-  "terraform_version": "0.12.1",
-  "serial": 34,
+  "terraform_version": "0.12.6",
+  "serial": 35,
   "lineage": "79b63ff1-f4e6-6d80-1075-d66cc148abdf",
   "outputs": {
     "ip_dev_id": {
@@ -69,7 +69,7 @@
             "ip_address": "116.203.5.95",
             "ip_network": null,
             "labels": {},
-            "server_id": 2826512,
+            "server_id": 3248152,
             "type": "ipv4"
           }
         }
@@ -90,7 +90,7 @@
             "ip_address": "2a01:4f8:1c0c:800b::",
             "ip_network": "2a01:4f8:1c0c:800b::/64",
             "labels": {},
-            "server_id": 2826512,
+            "server_id": 3248152,
             "type": "ipv6"
           }
         }
@@ -190,7 +190,7 @@
             "linux_device": "/dev/disk/by-id/scsi-0HC_Volume_2111019",
             "location": "nbg1",
             "name": "dev",
-            "server_id": 2826512,
+            "server_id": 3248152,
             "size": 10
           }
         }


### PR DESCRIPTION
I would like to remove influxdb.

[Victoriametrics](https://victoriametrics.com/) performance is way better and the original plan to use influxdb retention policy went up in flames (prometheus writes into a single measurement, writing cq for this is quite complicated)

I would delete all data in the influxdb since the only data that would be of interest is not very reliable atm