### PR TITLE
Limit Victoria Metrics RAM usage

### DIFF
--- a/deployment/roles/metrics/files/docker-compose.yml
+++ b/deployment/roles/metrics/files/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "--storageDataPath=/storage"
       - "--retentionPeriod=120"
       - "--httpListenAddr=:8428"
+      - "--memory.allowedPercent=30"
     networks:
       - default
     labels:


### PR DESCRIPTION
This limits the usage of RAM of Victoria Metrics (we don't need as much, so far it had all datapoints cached).