### PR TITLE
reverseproxy: Fix Android 6.0 tls

### DIFF
--- a/deployment/roles/reverseproxy/templates/security-headers.toml.j2
+++ b/deployment/roles/reverseproxy/templates/security-headers.toml.j2
@@ -2,17 +2,7 @@
     [tls.options.default]
       minVersion = "VersionTLS12"
       sniStrict = true
-      cipherSuites = [
-          "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-          "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-          "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-          "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-          "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
-          "TLS_AES_128_GCM_SHA256",
-          "TLS_AES_256_GCM_SHA384",
-          "TLS_CHACHA20_POLY1305_SHA256",
-          "TLS_FALLBACK_SCSV"
-      ]
+
 
 [http.middlewares]
     [http.middlewares.security-headers.headers]


### PR DESCRIPTION
Removed the cipherSuites list since the traefik default is now more sane and gives us an A+ rating on SSL Labs