### PR TITLE
Add ssh keys from spaceapi core team

### DIFF
--- a/deployment/playbooks/provisioning.yml
+++ b/deployment/playbooks/provisioning.yml
@@ -9,6 +9,14 @@
     - { role: motd, tags: ['motd'] }
     - { role: docker, tags: ['docker'] }
     - { role: watchtower, tags: ['watchtower'] }
+    - role: ssh_access
+      vars:
+        ssh_access_github_user:
+          - gidsi
+          - dbrgn
+          - rnestler
+          - s3lph
+      tags: access
 
     # services
     - { role: mattermost, tags: ['mattermost'] }

--- a/deployment/roles/ssh_access/defaults/main.yml
+++ b/deployment/roles/ssh_access/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+ssh_access_github_user:
+  - gidsi

--- a/deployment/roles/ssh_access/tasks/main.yml
+++ b/deployment/roles/ssh_access/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name:
+- name: Add ssh keys from github users
   blockinfile:
     block: "{{ lookup('url', 'https://github.com/' + item + '.keys', split_lines=False) }}"
     path: /root/.ssh/authorized_keys

--- a/deployment/roles/ssh_access/tasks/main.yml
+++ b/deployment/roles/ssh_access/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name:
+  blockinfile:
+    block: "{{ lookup('url', 'https://github.com/' + item + '.keys', split_lines=False) }}"
+    path: /root/.ssh/authorized_keys
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - {{ item }}"
+  with_items: "{{ ssh_access_github_user }}"
+


### PR DESCRIPTION
Add all the ssh keys!

I've added a list of github user names to the playbook in case we miss to add/remove somebody